### PR TITLE
Add tagging github action

### DIFF
--- a/.github/actions/get-dockerhub-version-tag/Dockerfile
+++ b/.github/actions/get-dockerhub-version-tag/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.16 as builder
+
+WORKDIR /app
+COPY . /app
+
+RUN go get -d -v
+
+# Statically compile our app for use in a distroless container
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -v -o app .
+
+# A distroless container image with some basics like SSL certificates
+# https://github.com/GoogleContainerTools/distroless
+FROM gcr.io/distroless/static
+
+COPY --from=builder /app/app /app
+
+ENTRYPOINT ["/app"]

--- a/.github/actions/get-dockerhub-version-tag/action.yml
+++ b/.github/actions/get-dockerhub-version-tag/action.yml
@@ -1,0 +1,16 @@
+name: 'Get Docker Hub image version tag'
+description: 'Get latest version tag for an image on Docker Hub'
+inputs:
+  org:
+    description: Docker Hub org
+    required: false
+    default: 'library'
+  repo:
+    description: Docker Hub repo
+    required: true
+outputs:
+  tag:
+    description: The latest version tag
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/get-dockerhub-version-tag/go.mod
+++ b/.github/actions/get-dockerhub-version-tag/go.mod
@@ -1,0 +1,8 @@
+module github.com/andreccosta/wordpress-xdebug-dockerbuild/.github/actions/get-dockerhub-version-tag
+
+go 1.16
+
+require (
+	github.com/coreos/go-semver v0.3.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/.github/actions/get-dockerhub-version-tag/go.sum
+++ b/.github/actions/get-dockerhub-version-tag/go.sum
@@ -1,0 +1,5 @@
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/.github/actions/get-dockerhub-version-tag/main.go
+++ b/.github/actions/get-dockerhub-version-tag/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+type dhtag struct {
+	Name string `json:"name"`
+}
+
+type dhrepo struct {
+	Count   int     `json:"count"`
+	Results []dhtag `json:"results"`
+}
+
+func main() {
+	org := os.Getenv("INPUT_ORG")
+	repo := os.Getenv("INPUT_REPO")
+
+	if org == "" {
+		org = "library"
+	}
+
+	if repo == "" {
+		log.Fatal("Repo is required")
+	}
+
+	url := fmt.Sprintf(`https://hub.docker.com/v2/repositories/%s/%s/tags/?page_size=1000&ordering=last_updated`, org, repo)
+
+	dhClient := http.Client{
+		Timeout: time.Second * 2, // Maximum of 2 secs
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req.Header.Set("User-Agent", "get-dockerhub-version-tag-action")
+
+	res, getErr := dhClient.Do(req)
+	if getErr != nil {
+		log.Fatal(getErr)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	dhrepo1 := dhrepo{}
+	unmarshalErr := json.Unmarshal(body, &dhrepo1)
+	if unmarshalErr != nil {
+		log.Fatal(unmarshalErr)
+	}
+
+	var tags []*semver.Version
+	for _, tag := range dhrepo1.Results {
+		matched, _ := regexp.MatchString(`^[vV]*[0-9]+\.[0-9]+\.[0-9]+$`, tag.Name)
+
+		if matched {
+			log.Printf("Matched %s", tag.Name)
+			tags = append(tags, semver.New(strings.Trim(tag.Name, "vV")))
+		}
+	}
+
+	if len(tags) == 0 {
+		log.Fatal(fmt.Sprintf(`Unable to find tags for %s/%s`, org, repo))
+	}
+
+	semver.Sort(tags)
+	fmt.Println(fmt.Sprintf(`::set-output name=tag::%s`, tags[len(tags)-1]))
+}

--- a/.github/actions/get-pecl-package-version/Dockerfile
+++ b/.github/actions/get-pecl-package-version/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.16 as builder
+
+WORKDIR /app
+COPY . /app
+
+RUN go get -d -v
+
+# Statically compile our app for use in a distroless container
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -v -o app .
+
+# A distroless container image with some basics like SSL certificates
+# https://github.com/GoogleContainerTools/distroless
+FROM gcr.io/distroless/static
+
+COPY --from=builder /app/app /app
+
+ENTRYPOINT ["/app"]

--- a/.github/actions/get-pecl-package-version/action.yml
+++ b/.github/actions/get-pecl-package-version/action.yml
@@ -1,0 +1,19 @@
+name: 'Get PECL package latest version'
+description: 'Get latest version for a PECL package'
+inputs:
+  package:
+    description: Package name
+    required: true
+  stability:
+    description: Version stability
+    required: false
+    default: 'stable'
+  filter:
+    description: Version filter
+    required: false
+outputs:
+  version:
+    description: The latest version
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/get-pecl-package-version/go.mod
+++ b/.github/actions/get-pecl-package-version/go.mod
@@ -1,0 +1,8 @@
+module github.com/andreccosta/wordpress-xdebug-dockerbuild/.github/actions/get-pecl-package-versions
+
+go 1.16
+
+require (
+	github.com/coreos/go-semver v0.3.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/.github/actions/get-pecl-package-version/go.sum
+++ b/.github/actions/get-pecl-package-version/go.sum
@@ -1,0 +1,5 @@
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/.github/actions/get-pecl-package-version/main.go
+++ b/.github/actions/get-pecl-package-version/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+type AllReleases struct {
+	XMLName  xml.Name  `xml:"a"`
+	Releases []Release `xml:"r"`
+}
+
+type Release struct {
+	Version   string `xml:"v"`
+	Stability string `xml:"s"`
+}
+
+func main() {
+	pkg := os.Getenv("INPUT_PACKAGE")
+	stbl := os.Getenv("INPUT_STABILITY")
+	filter := os.Getenv("INPUT_FILTER")
+
+	if pkg == "" {
+		log.Fatal("Package name is required")
+	}
+
+	if stbl == "" {
+		stbl = "stable"
+	}
+
+	url := fmt.Sprintf(`https://pecl.php.net/rest/r/%s/allreleases.xml`, pkg)
+
+	log.Print(url)
+
+	client := http.Client{
+		Timeout: time.Second * 2, // Maximum of 2 secs
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req.Header.Set("User-Agent", "get-pecl-package-version-action")
+
+	res, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var allReleases AllReleases
+	xml.Unmarshal(body, &allReleases)
+
+	var versions []*semver.Version
+	for _, release := range allReleases.Releases {
+		if release.Stability != stbl {
+			continue
+		}
+
+		version := strings.Trim(release.Version, "vV")
+
+		if filter != "" && !strings.HasPrefix(version, filter) {
+			continue
+		}
+
+		matched, _ := regexp.MatchString(`^[vV]*[0-9]+\.[0-9]+\.[0-9]+$`, version)
+
+		if matched {
+			versions = append(versions, semver.New(release.Version))
+		}
+	}
+
+	if len(versions) == 0 {
+		log.Fatal(fmt.Sprintf(`Unable to find versions for package %s`, pkg))
+	}
+
+	semver.Sort(versions)
+	fmt.Println(fmt.Sprintf(`::set-output name=version::%s`, versions[len(versions)-1]))
+}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,19 @@
+name: Docker build
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          docker build . --file Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker publish
 
 on:
   push:
@@ -6,29 +6,55 @@ on:
       - main
 
     tags:
-      - v*
-
-  pull_request:
+      - wp*
 
 env:
   IMAGE_NAME: wordpress-xdebug
 
 jobs:
-  test:
+  tag:
     runs-on: ubuntu-latest
+
+    outputs:
+      tag: ${{ steps.create-tag.outputs.tag }}
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run tests
-        run: |
-          docker build . --file Dockerfile
+      - name: Get dockerhub wordpress latest version tag
+        id: image-tag
+        uses: ./.github/actions/get-dockerhub-version-tag
+        with:
+          org: 'library'
+          repo: 'wordpress'
+
+      - name: Get Xdebug pecl package version
+        id: package-version
+        uses: ./.github/actions/get-pecl-package-version
+        with:
+          package: 'xdebug'
+          stability: 'stable'
+
+      - name: Create tag
+        id: create-tag
+        run: echo "::set-output name=tag::wp${{ steps.image-tag.outputs.tag}}-xdebug${{ steps.package-version.outputs.version }}"
+
+      - name: Push tag
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.create-tag.outputs.tag }}",
+              sha: context.sha
+            })
 
   push:
     needs: test
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v2
@@ -46,17 +72,12 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
+          # Version from created tag
+          VERSION=${{ needs.tag.outputs.tag }}
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
Add local workflow actions to obtain latest version of both the wordpress image tag and Xdebug package version and use those as complementary tag in docker image.